### PR TITLE
Updated the links in docs to match the markdown sytnax. (#4800)

### DIFF
--- a/tensorflow/contrib/session_bundle/README.md
+++ b/tensorflow/contrib/session_bundle/README.md
@@ -4,8 +4,8 @@
 
 ## Overview
 
-This document describes the data formats and layouts for exporting [TensorFlow]
-(https://www.tensorflow.org/) models for inference.
+This document describes the data formats and layouts for exporting
+[TensorFlow](https://www.tensorflow.org/) models for inference.
 
 These exports have the following properties:
 
@@ -50,8 +50,8 @@ binary.
 
 ### Exporting TF.learn models
 
-TF.learn uses an [Exporter wrapper]
-(https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/learn/python/learn/utils/export.py)
+TF.learn uses an
+[Exporter wrapper](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/learn/python/learn/utils/export.py)
 that can be used for building signatures. Use the `BaseEstimator.export`
 function to export your Estimator with a signature.
 

--- a/tensorflow/core/ops/nn_ops.cc
+++ b/tensorflow/core/ops/nn_ops.cc
@@ -1071,8 +1071,7 @@ each component is divided by the weighted, squared sum of inputs within
     output = input / (bias + alpha * sqr_sum) ** beta
 
 For details, see [Krizhevsky et al., ImageNet classification with deep
-convolutional neural networks (NIPS 2012)]
-(http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks).
+convolutional neural networks (NIPS 2012)](http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks).
 
 input: 4-D.
 depth_radius: 0-D.  Half-width of the 1-D normalization window.
@@ -1825,8 +1824,7 @@ Then, row_pooling_sequence should satisfy:
 4.  length(row_pooling_sequence) = output_row_length+1
 
 For more details on fractional max pooling, see this paper:
-[Benjamin Graham, Fractional Max-Pooling]
-(http://arxiv.org/abs/1412.6071)
+[Benjamin Graham, Fractional Max-Pooling](http://arxiv.org/abs/1412.6071)
 
 value: 4-D with shape `[batch, height, width, channels]`.
 pooling_ratio: Pooling ratio for each dimension of `value`, currently only

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard1/tf.nn.sampled_softmax_loss.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard1/tf.nn.sampled_softmax_loss.md
@@ -11,8 +11,8 @@ the full softmax loss.
 At inference time, you can compute full softmax probabilities with the
 expression `tf.nn.softmax(tf.matmul(inputs, tf.transpose(weights)) + biases)`.
 
-See our [Candidate Sampling Algorithms Reference]
-(../../extras/candidate_sampling.pdf)
+See our
+[Candidate Sampling Algorithms Reference](../../extras/candidate_sampling.pdf)
 
 Also see Section 3 of [Jean et al., 2014](http://arxiv.org/abs/1412.2007)
 ([pdf](http://arxiv.org/pdf/1412.2007.pdf)) for the math.

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard2/tf.Graph.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard2/tf.Graph.md
@@ -632,8 +632,8 @@ Note that this is unrelated to the
 
 The GraphDef version information of this graph.
 
-For details on the meaning of each version, see [`GraphDef`]
-(https://www.tensorflow.org/code/tensorflow/core/framework/graph.proto).
+For details on the meaning of each version, see
+[`GraphDef`](https://www.tensorflow.org/code/tensorflow/core/framework/graph.proto).
 
 ##### Returns:
 

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard3/tf.nn.fractional_max_pool.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard3/tf.nn.fractional_max_pool.md
@@ -29,8 +29,7 @@ Then, row_pooling_sequence should satisfy:
 4.  length(row_pooling_sequence) = output_row_length+1
 
 For more details on fractional max pooling, see this paper:
-[Benjamin Graham, Fractional Max-Pooling]
-(http://arxiv.org/abs/1412.6071)
+[Benjamin Graham, Fractional Max-Pooling](http://arxiv.org/abs/1412.6071)
 
 ##### Args:
 

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard4/tf.nn.nce_loss.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard4/tf.nn.nce_loss.md
@@ -2,11 +2,10 @@
 
 Computes and returns the noise-contrastive estimation training loss.
 
-See [Noise-contrastive estimation: A new estimation principle for
-unnormalized statistical models]
-(http://www.jmlr.org/proceedings/papers/v9/gutmann10a/gutmann10a.pdf).
-Also see our [Candidate Sampling Algorithms Reference]
-(../../extras/candidate_sampling.pdf)
+See
+[Noise-contrastive estimation: A new estimation principle for unnormalized statistical models](http://www.jmlr.org/proceedings/papers/v9/gutmann10a/gutmann10a.pdf).
+Also see our
+[Candidate Sampling Algorithms Reference](../../extras/candidate_sampling.pdf)
 
 Note: By default this uses a log-uniform (Zipfian) distribution for sampling,
 so your labels must be sorted in order of decreasing frequency to achieve

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard6/tf.parse_example.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard6/tf.parse_example.md
@@ -2,8 +2,8 @@
 
 Parses `Example` protos into a `dict` of tensors.
 
-Parses a number of serialized [`Example`]
-(https://www.tensorflow.org/code/tensorflow/core/example/example.proto)
+Parses a number of serialized
+[`Example`](https://www.tensorflow.org/code/tensorflow/core/example/example.proto)
 protos given in `serialized`.
 
 `example_names` may contain descriptive names for the corresponding serialized

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard6/tf.train.RMSPropOptimizer.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard6/tf.train.RMSPropOptimizer.md
@@ -1,7 +1,6 @@
 Optimizer that implements the RMSProp algorithm.
 
-See the [paper]
-(http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf).
+See the [paper](http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf).
 
 - - -
 

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard7/tf.nn.atrous_conv2d.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard7/tf.nn.atrous_conv2d.md
@@ -32,11 +32,10 @@ Convolutional Nets and Fully Connected CRFs](http://arxiv.org/abs/1412.7062).
 The same operation is investigated further in [Multi-Scale Context Aggregation
 by Dilated Convolutions](http://arxiv.org/abs/1511.07122). Previous works
 that effectively use atrous convolution in different ways are, among others,
-[OverFeat: Integrated Recognition, Localization and Detection using
-Convolutional Networks](http://arxiv.org/abs/1312.6229) and [Fast Image
-Scanning with Deep Max-Pooling Convolutional Neural Networks]
-(http://arxiv.org/abs/1302.1700). Atrous convolution is also closely related
-to the so-called noble identities in multi-rate signal processing.
+[OverFeat: Integrated Recognition, Localization and Detection using Convolutional Networks](http://arxiv.org/abs/1312.6229)
+and [Fast Image Scanning with Deep Max-Pooling Convolutional Neural Networks](http://arxiv.org/abs/1302.1700).
+Atrous convolution is also closely related to the so-called noble identities in
+multi-rate signal processing.
 
 There are many different ways to implement atrous convolution (see the refs
 above). The implementation here reduces

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard7/tf.nn.local_response_normalization.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard7/tf.nn.local_response_normalization.md
@@ -11,9 +11,8 @@ each component is divided by the weighted, squared sum of inputs within
         sum(input[a, b, c, d - depth_radius : d + depth_radius + 1] ** 2)
     output = input / (bias + alpha * sqr_sum) ** beta
 
-For details, see [Krizhevsky et al., ImageNet classification with deep
-convolutional neural networks (NIPS 2012)]
-(http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks).
+For details, see
+[Krizhevsky et al., ImageNet classification with deep convolutional neural networks (NIPS 2012)](http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks).
 
 ##### Args:
 

--- a/tensorflow/g3doc/api_docs/python/functions_and_classes/shard8/tf.Session.md
+++ b/tensorflow/g3doc/api_docs/python/functions_and_classes/shard8/tf.Session.md
@@ -36,8 +36,7 @@ with tf.Session() as sess:
   sess.run(...)
 ```
 
-The [`ConfigProto`]
-(https://www.tensorflow.org/code/tensorflow/core/protobuf/config.proto)
+The [`ConfigProto`](https://www.tensorflow.org/code/tensorflow/core/protobuf/config.proto)
 protocol buffer exposes various configuration options for a
 session. For example, to create a session that uses soft constraints
 for device placement, and log the resulting placement decisions,

--- a/tensorflow/g3doc/how_tos/image_retraining/index.md
+++ b/tensorflow/g3doc/how_tos/image_retraining/index.md
@@ -199,8 +199,8 @@ will end up basing its prediction on the background color, not the features of
 the object you actually care about. To avoid this, try to take pictures in as
 wide a variety of situations as you can, at different times, and with different
 devices. If you want to know more about this problem, you can read about the
-classic (and possibly apocryphal) [tank recognition problem]
-(http://www.jefftk.com/p/detecting-tanks).
+classic (and possibly apocryphal)
+[tank recognition problem](http://www.jefftk.com/p/detecting-tanks).
 
 You may also want to think about the categories you use. It might be worth
 splitting big categories that cover a lot of different physical forms into

--- a/tensorflow/g3doc/how_tos/quantization/index.md
+++ b/tensorflow/g3doc/how_tos/quantization/index.md
@@ -200,10 +200,9 @@ Quantized | Float
 The advantages of this format are that it can represent arbitrary magnitudes of
 ranges, they don't have to be symmetrical, it can represent signed and unsigned
 values, and the linear spread makes doing multiplications straightforward. There
-are alternatives like [Song Han's code books]
-(http://arxiv.org/pdf/1510.00149.pdf) that can use lower bit depths by
-non-linearly distributing the float values across the representation, but these
-tend to be more expensive to calculate on.
+are alternatives like [Song Han's code books](http://arxiv.org/pdf/1510.00149.pdf)
+that can use lower bit depths by non-linearly distributing the float values
+across the representation, but these tend to be more expensive to calculate on.
 
 The advantage of having a strong and clear definition of the quantized format is
 that it's always possible to convert back and forth from float for operations
@@ -226,11 +225,11 @@ results from 8-bit inputs.
 
 We've found that we can get extremely good performance on mobile and embedded
 devices by using eight-bit arithmetic rather than floating-point. You can see
-the framework we use to optimize matrix multiplications at [gemmlowp]
-(https://github.com/google/gemmlowp). We still need to apply all the lessons
-we've learned to the TensorFlow ops to get maximum performance on mobile, but
-we're actively working on that. Right now, this quantized implementation is a
-reasonably fast and accurate reference implementation that we're hoping will
-enable wider support for our eight-bit models on a wider variety of devices. We
-also hope that this demonstration will encourage the community to explore what's
-possible with low-precision neural networks.
+the framework we use to optimize matrix multiplications at
+[gemmlowp](https://github.com/google/gemmlowp). We still need to apply all the
+lessons we've learned to the TensorFlow ops to get maximum performance on
+mobile, but we're actively working on that. Right now, this quantized
+implementation is a reasonably fast and accurate reference implementation that
+we're hoping will enable wider support for our eight-bit models on a wider
+variety of devices. We also hope that this demonstration will encourage the
+community to explore what's possible with low-precision neural networks.

--- a/tensorflow/g3doc/how_tos/summaries_and_tensorboard/index.md
+++ b/tensorflow/g3doc/how_tos/summaries_and_tensorboard/index.md
@@ -24,8 +24,7 @@ lifecycle for summary data within TensorBoard.
 
 First, create the TensorFlow graph that you'd like to collect summary
 data from, and decide which nodes you would like to annotate with
-[summary operations]
-(../../api_docs/python/train.md#summary-operations).
+[summary operations](../../api_docs/python/train.md#summary-operations).
 
 For example, suppose you are training a convolutional neural network for
 recognizing MNIST digits. You'd like to record how the learning rate
@@ -42,8 +41,7 @@ this data by attaching
 the gradient outputs and to the variable that holds your weights, respectively.
 
 For details on all of the summary operations available, check out the docs on
-[summary operations]
-(../../api_docs/python/train.md#summary-operations).
+[summary operations](../../api_docs/python/train.md#summary-operations).
 
 Operations in TensorFlow don't do anything until you run them, or an op that
 depends on their output. And the summary nodes that we've just created are
@@ -72,12 +70,13 @@ every single step, and record a ton of training data. That's likely to be more
 data than you need, though. Instead, consider running the merged summary op
 every `n` steps.
 
-The code example below is a modification of the [simple MNIST tutorial]
-(http://tensorflow.org/tutorials/mnist/beginners/index.md), in which we have
-added some summary ops, and run them every ten steps. If you run this and then
-launch `tensorboard --logdir=/tmp/mnist_logs`, you'll be able to visualize
-statistics, such as how the weights or accuracy varied during training.
-The code below is an excerpt; full source is [here](https://www.tensorflow.org/code/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py).
+The code example below is a modification of the
+[simple MNIST tutorial](http://tensorflow.org/tutorials/mnist/beginners/index.md),
+in which we have added some summary ops, and run them every ten steps. If you
+run this and then launch `tensorboard --logdir=/tmp/mnist_logs`, you'll be able
+to visualize statistics, such as how the weights or accuracy varied during
+training. The code below is an excerpt; full source is
+[here](https://www.tensorflow.org/code/tensorflow/examples/tutorials/mnist/mnist_with_summaries.py).
 
 ```python
 def variable_summaries(var, name):

--- a/tensorflow/g3doc/how_tos/tool_developers/index.md
+++ b/tensorflow/g3doc/how_tos/tool_developers/index.md
@@ -11,11 +11,11 @@ those kind of tools.
 
 ## Protocol Buffers
 
-All of TensorFlow's file formats are based on [Protocol Buffers]
-(https://developers.google.com/protocol-buffers/?hl=en), so to start
-it's worth getting familiar with how they work. The summary is that you define
-data structures in text files, and the protobuf tools generate classes in C,
-Python, and other languages that can load, save, and access the data in a
+All of TensorFlow's file formats are based on
+[Protocol Buffers](https://developers.google.com/protocol-buffers/?hl=en), so to
+start it's worth getting familiar with how they work. The summary is that you
+define data structures in text files, and the protobuf tools generate classes in
+C, Python, and other languages that can load, save, and access the data in a
 friendly way. We often refer to Protocol Buffers as protobufs, and I'll use
 that convention in this guide.
 

--- a/tensorflow/g3doc/resources/faq.md
+++ b/tensorflow/g3doc/resources/faq.md
@@ -261,8 +261,8 @@ these summaries to a log directory.  Then, start TensorBoard using
 
     python tensorflow/tensorboard/tensorboard.py --logdir=path/to/log-directory
 
-For more details, see the [Summaries and TensorBoard tutorial]
-(../how_tos/summaries_and_tensorboard/index.md).
+For more details, see the
+[Summaries and TensorBoard tutorial](../how_tos/summaries_and_tensorboard/index.md).
 
 #### Every time I launch TensorBoard, I get a network security popup!
 
@@ -279,9 +279,9 @@ See also the how-to documentation for
 There are two main options for dealing with data in a custom format.
 
 The easier option is to write parsing code in Python that transforms the data
-into a numpy array, then feed a [`tf.placeholder()`]
-(../api_docs/python/io_ops.md#placeholder) a tensor with that data. See the
-documentation on
+into a numpy array, then feed a
+[`tf.placeholder()`](../api_docs/python/io_ops.md#placeholder) a tensor with
+that data. See the documentation on
 [using placeholders for input](../how_tos/reading_data/index.md#feeding) for
 more details. This approach is easy to get up and running, but the parsing can
 be a performance bottleneck.

--- a/tensorflow/g3doc/resources/xla_prerelease.md
+++ b/tensorflow/g3doc/resources/xla_prerelease.md
@@ -127,8 +127,8 @@ an `xla::Client` object.
 
 The `ComputationBuilder` class provides a convenient programming interface to
 construct XLA computations. The semantics of XLA operations with links
-to `ComputationBuilder` methods are documented in [Operation Semantics]
-(#operation_semantics).
+to `ComputationBuilder` methods are documented in
+[Operation Semantics](#operation_semantics).
 
 Here is the part that JIT-compiles the graph (step 2):
 
@@ -1355,10 +1355,10 @@ shape of the output array. The array `pred` must have the same dimensionality as
 
 For each element `P` of `pred`, the corresponding element of the output array is
 taken from `on_true` if the value of `P` is `true`, and from `on_false` if the
-value of `P` is `false`. As a restricted form of [broadcasting]
-(#broadcasting_semantics), `pred` can be a scalar of type `PRED`. In this case,
-the output array is taken wholly from `on_true` if `pred` is `true`, and from
-`on_false` if `pred` is `false`.
+value of `P` is `false`. As a restricted form of
+[broadcasting](#broadcasting_semantics), `pred` can be a scalar of type `PRED`.
+In this case, the output array is taken wholly from `on_true` if `pred` is
+`true`, and from `on_false` if `pred` is `false`.
 
 Example with non-scalar `pred`:
 
@@ -1477,8 +1477,8 @@ let s: s32 = 5;
 let t: (f32[10], s32) = tuple(v, s);
 ```
 
-Tuples can be deconstructed (accessed) via the [`GetTupleElement`]
-(#gettupleelement) operation.
+Tuples can be deconstructed (accessed) via the
+[`GetTupleElement`](#gettupleelement) operation.
 
 ### While
 
@@ -1553,8 +1553,8 @@ by replicating it over rows to get:
     |1 2 3| + |7 8 9| = |8  10 12|
     |4 5 6|   |7 8 9|   |11 13 15|
 
-In Numpy, this is called [broadcasting]
-(http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html).
+In Numpy, this is called
+[broadcasting](http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html).
 
 ### Principles
 
@@ -1690,8 +1690,7 @@ Examples:
 A special case arises, and is also supported, where each of the input arrays has
 a degenerate dimension at a different index. In this case, we get an "outer
 operation": (2,1) and (1,3) broadcast to (2,3). For more examples, consult the
-[Numpy documentation on broadcasting]
-(http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html).
+[Numpy documentation on broadcasting](http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html).
 
 ### Broadcast composition
 

--- a/tensorflow/g3doc/tutorials/deep_cnn/index.md
+++ b/tensorflow/g3doc/tutorials/deep_cnn/index.md
@@ -32,17 +32,15 @@ new ideas and experimenting with new techniques.
 The CIFAR-10 tutorial demonstrates several important constructs for
 designing larger and more sophisticated models in TensorFlow:
 
-* Core mathematical components including [convolution](
-../../api_docs/python/nn.md#conv2d) ([wiki](
-https://en.wikipedia.org/wiki/Convolution)), [rectified linear activations](
-../../api_docs/python/nn.md#relu) ([wiki](
-https://en.wikipedia.org/wiki/Rectifier_(neural_networks))), [max pooling](
-../../api_docs/python/nn.md#max_pool) ([wiki](
-https://en.wikipedia.org/wiki/Convolutional_neural_network#Pooling_layer))
-and [local response normalization](
-../../api_docs/python/nn.md#local_response_normalization) 
-(Chapter 3.3 in [AlexNet paper](
-http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf)).
+* Core mathematical components including [convolution](../../api_docs/python/nn.md#conv2d)
+([wiki](https://en.wikipedia.org/wiki/Convolution)),
+[rectified linear activations](../../api_docs/python/nn.md#relu)
+([wiki](https://en.wikipedia.org/wiki/Rectifier_(neural_networks))),
+[max pooling](../../api_docs/python/nn.md#max_pool)
+([wiki](https://en.wikipedia.org/wiki/Convolutional_neural_network#Pooling_layer))
+and [local response normalization](../../api_docs/python/nn.md#local_response_normalization)
+(Chapter 3.3 in
+[AlexNet paper](http://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf)).
 * [Visualization](../../how_tos/summaries_and_tensorboard/index.md)
 of network activities during training, including input images,
 losses and distributions of activations and gradients.
@@ -57,7 +55,7 @@ that systematically decrements over time.
 for input
 data to isolate the model from disk latency and expensive image pre-processing.
 
-We also provide a [multi-GPU version](#training-a-model-using-multiple-gpu-cards) 
+We also provide a [multi-GPU version](#training-a-model-using-multiple-gpu-cards)
 of the model which demonstrates:
 
 * Configuring a model to train across multiple GPU cards in parallel.
@@ -111,7 +109,7 @@ adds operations that perform inference, i.e. classification, on supplied images.
 add operations that compute the loss,
 gradients, variable updates and visualization summaries.
 
-### Model Inputs 
+### Model Inputs
 
 The input part of the model is built by the functions `inputs()` and
 `distorted_inputs()` which read images from the CIFAR-10 binary data files.
@@ -149,7 +147,7 @@ processing time. To prevent these operations from slowing down training, we run
 them inside 16 separate threads which continuously fill a TensorFlow
 [queue](../../api_docs/python/io_ops.md#shuffle_batch).
 
-### Model Prediction 
+### Model Prediction
 
 The prediction part of the model is constructed by the `inference()` function
 which adds operations to compute the *logits* of the predictions. That part of
@@ -174,8 +172,8 @@ Here is a graph generated from TensorBoard describing the inference operation:
 </div>
 
 > **EXERCISE**: The output of `inference` are un-normalized logits. Try editing
-the network architecture to return normalized predictions using [`tf.nn.softmax()`]
-(../../api_docs/python/nn.md#softmax).
+the network architecture to return normalized predictions using
+[`tf.nn.softmax()`](../../api_docs/python/nn.md#softmax).
 
 The `inputs()` and `inference()` functions provide all the components
 necessary to perform evaluation on a model. We now shift our focus towards
@@ -188,7 +186,7 @@ layers of Alex's original model are locally connected and not fully connected.
 Try editing the architecture to exactly reproduce the locally connected
 architecture in the top layer.
 
-### Model Training 
+### Model Training
 
 The usual method for training a network to perform N-way classification is
 [multinomial logistic regression](https://en.wikipedia.org/wiki/Multinomial_logistic_regression),
@@ -307,7 +305,7 @@ values.  See how the scripts use
 [`ExponentialMovingAverage`](../../api_docs/python/train.md#ExponentialMovingAverage)
 for this purpose.
 
-## Evaluating a Model 
+## Evaluating a Model
 
 Let us now evaluate how well the trained model performs on a hold-out data set.
 The model is evaluated by the script `cifar10_eval.py`.  It constructs the model

--- a/tensorflow/g3doc/tutorials/image_recognition/index.md
+++ b/tensorflow/g3doc/tutorials/image_recognition/index.md
@@ -160,13 +160,13 @@ are between 0 and 255 to the floating point values that the graph operates on.
 We control the scaling with the `input_mean` and `input_std` flags: we first subtract
 `input_mean` from each pixel value, then divide it by `input_std`.
 
-These values probably look somewhat magical, but they are just defined by the 
-original model author based on what he/she wanted to use as input images for 
+These values probably look somewhat magical, but they are just defined by the
+original model author based on what he/she wanted to use as input images for
 training. If you have a graph that you've trained yourself, you'll just need
 to adjust the values to match whatever you used during your training process.
 
-You can see how they're applied to an image in the [`ReadTensorFromImageFile()`]
-(https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/label_image/main.cc#L88)
+You can see how they're applied to an image in the
+[`ReadTensorFromImageFile()`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/label_image/main.cc#L88)
 function.
 
 ```C++
@@ -255,8 +255,8 @@ definition with the `ToGraphDef()` function.
   TF_RETURN_IF_ERROR(session->Run({}, {output_name}, {}, out_tensors));
   return Status::OK();
 ```
-Then we create a [`Session`](http://www.tensorflow.org/versions/master/api_docs/cc/ClassSession.html#class-tensorflow-session) 
-object, which is the interface to actually running the graph, and run it, 
+Then we create a [`Session`](http://www.tensorflow.org/versions/master/api_docs/cc/ClassSession.html#class-tensorflow-session)
+object, which is the interface to actually running the graph, and run it,
 specifying which node we want to get the output from, and where to put the
 output data.
 
@@ -434,7 +434,7 @@ TensorFlow within your own products.
 > **EXERCISE**: Transfer learning is the idea that, if you know how to solve a task well, you
 should be able to transfer some of that understanding to solving related
 problems.  One way to perform transfer learning is to remove the final
-classification layer of the network and extract 
+classification layer of the network and extract
 the [next-to-last layer of the CNN](http://arxiv.org/abs/1310.1531), in this case a 2048 dimensional vector.
 There's a guide to doing this [in the how-to section](../../how_tos/image_retraining/index.html).
 

--- a/tensorflow/g3doc/tutorials/input_fn/index.md
+++ b/tensorflow/g3doc/tutorials/input_fn/index.md
@@ -104,8 +104,8 @@ This corresponds to the following dense tensor:
  [0, 0, 0, 0, 0.5]]
 ```
 
-For more on `SparseTensor`, see the [TensorFlow API documentation]
-(../../api_docs/python/sparse_ops.md#SparseTensor).
+For more on `SparseTensor`, see the
+[TensorFlow API documentation](../../api_docs/python/sparse_ops.md#SparseTensor).
 
 ### Passing input_fn Data to Your Model
 
@@ -153,9 +153,9 @@ classifier.fit(input_fn=functools.partial(my_input_function,
                                           data_set=training_set), steps=2000)
 ```
 
-A third option is to wrap your input_fn invocation in a [`lambda`]
-(https://docs.python.org/3/tutorial/controlflow.html#lambda-expressions) and
-pass it to the `input_fn` parameter:
+A third option is to wrap your input_fn invocation in a
+[`lambda`](https://docs.python.org/3/tutorial/controlflow.html#lambda-expressions)
+and pass it to the `input_fn` parameter:
 
 ```python
 classifier.fit(input_fn=lambda: my_input_fn(training_set), steps=2000)
@@ -181,8 +181,8 @@ Set](https://archive.ics.uci.edu/ml/datasets/Housing) and use it to feed data to
 a neural network regressor for predicting median house values.
 
 The [Boston CSV data sets](#setup) you'll use to train your neural network
-contain the following [feature data]
-(https://archive.ics.uci.edu/ml/machine-learning-databases/housing/housing.names)
+contain the following
+[feature data](https://archive.ics.uci.edu/ml/machine-learning-databases/housing/housing.names)
 for Boston suburbs:
 
 Feature | Description
@@ -202,10 +202,10 @@ owner-occupied residences in thousands of dollars.
 
 ## Setup {#setup}
 
-Download the following data sets: [boston_train.csv]
-(http://download.tensorflow.org/data/boston_train.csv), [boston_test.csv]
-(http://download.tensorflow.org/data/boston_test.csv), and [boston_predict.csv]
-(http://download.tensorflow.org/data/boston_predict.csv).
+Download the following data sets:
+[boston_train.csv](http://download.tensorflow.org/data/boston_train.csv),
+[boston_test.csv](http://download.tensorflow.org/data/boston_test.csv), and
+[boston_predict.csv](http://download.tensorflow.org/data/boston_predict.csv).
 
 The following sections provide a step-by-step walkthrough of how to create an
 input function, feed these data sets into a neural network regressor, train and
@@ -230,9 +230,9 @@ tf.logging.set_verbosity(tf.logging.INFO)
 
 Define the column names for the data set in `COLUMNS`. To distinguish features
 from the label, also define `FEATURES` and `LABEL`. Then read the three CSVs
-([train](http://download.tensorflow.org/data/boston_train.csv), [test]
-(http://download.tensorflow.org/data/boston_test.csv), and [predict]
-(http://download.tensorflow.org/data/boston_predict.csv)) into _pandas_
+([train](http://download.tensorflow.org/data/boston_train.csv),
+[test](http://download.tensorflow.org/data/boston_test.csv), and
+[predict](http://download.tensorflow.org/data/boston_predict.csv)) into _pandas_
 `DataFrame`s:
 
 ```python
@@ -262,10 +262,10 @@ feature_cols = [tf.contrib.layers.real_valued_column(k)
                   for k in FEATURES]
 ```
 
-NOTE: For a more in-depth overview of feature columns, see [this introduction]
-(../linear/overview.md#feature-columns-and-transformations), and for an example
-that illustrates how to define `FeatureColumns` for categorical data, see the
-[Linear Model Tutorial](../wide/index.md).
+NOTE: For a more in-depth overview of feature columns, see
+[this introduction](../linear/overview.md#feature-columns-and-transformations),
+and for an example that illustrates how to define `FeatureColumns` for
+categorical data, see the [Linear Model Tutorial](../wide/index.md).
 
 Now, instantiate a `DNNRegressor` for the neural network regression model.
 You'll need to provide two arguments here: `hidden_units`, a hyperparameter

--- a/tensorflow/g3doc/tutorials/linear/overview.md
+++ b/tensorflow/g3doc/tutorials/linear/overview.md
@@ -158,7 +158,7 @@ transformation lets you use continuous features in feature crosses, or learn
 cases where specific value ranges have particular importance.
 
 Bucketization divides the range of possible values into subranges called
-buckets: 
+buckets:
 
 ```python
 age_buckets = tf.contrib.layers.bucketized_column(
@@ -178,9 +178,8 @@ The input function must return a dictionary of tensors. Each key corresponds to
 the name of a `FeatureColumn`. Each key's value is a tensor containing the
 values of that feature for all data instances. See
 [Building Input Functions with tf.contrib.learn](../input_fn/index.md) for a
-more comprehensive look at input functions, and `input_fn` in the [linear
-models tutorial code]
-(https://www.tensorflow.org/code/tensorflow/examples/learn/wide_n_deep_tutorial.py)
+more comprehensive look at input functions, and `input_fn` in the
+[linear models tutorial code](https://www.tensorflow.org/code/tensorflow/examples/learn/wide_n_deep_tutorial.py)
 for an example implementation of an input function.
 
 The input function is passed to the `fit()` and `evaluate()` calls that

--- a/tensorflow/g3doc/tutorials/mnist/beginners/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/beginners/index.md
@@ -368,9 +368,8 @@ In this case, we ask TensorFlow to minimize `cross_entropy` using the
 with a learning rate of 0.5. Gradient descent is a simple procedure, where
 TensorFlow simply shifts each variable a little bit in the direction that
 reduces the cost. But TensorFlow also provides
-[many other optimization algorithms]
-(../../../api_docs/python/train.md#optimizers): using one is as simple as
-tweaking one line.
+[many other optimization algorithms](../../../api_docs/python/train.md#optimizers):
+using one is as simple as tweaking one line.
 
 What TensorFlow actually does here, behind the scenes, is to add new operations
 to your graph which implement backpropagation and gradient descent. Then it

--- a/tensorflow/g3doc/tutorials/mnist/pros/index.md
+++ b/tensorflow/g3doc/tutorials/mnist/pros/index.md
@@ -186,10 +186,9 @@ Now that we have defined our model and training loss function, it is
 straightforward to train using TensorFlow.  Because TensorFlow knows the entire
 computation graph, it can use automatic differentiation to find the gradients of
 the loss with respect to each of the variables.  TensorFlow has a variety of
-[built-in optimization algorithms]
-(../../../api_docs/python/train.md#optimizers).  For this example, we will use
-steepest gradient descent, with a step length of 0.5, to descend the cross
-entropy.
+[built-in optimization algorithms](../../../api_docs/python/train.md#optimizers).
+For this example, we will use steepest gradient descent, with a step length of
+0.5, to descend the cross entropy.
 
 ```python
 train_step = tf.train.GradientDescentOptimizer(0.5).minimize(cross_entropy)
@@ -380,7 +379,7 @@ y_conv = tf.matmul(h_fc1_drop, W_fc2) + b_fc2
 How well does this model do? To train and evaluate it we will use code that is
 nearly identical to that for the simple one layer SoftMax network above.
 
-The differences are that: 
+The differences are that:
 
 - We will replace the steepest gradient descent optimizer with the more
   sophisticated ADAM optimizer.

--- a/tensorflow/g3doc/tutorials/monitors/index.md
+++ b/tensorflow/g3doc/tutorials/monitors/index.md
@@ -57,9 +57,9 @@ y = classifier.predict(new_samples)
 print('Predictions: {}'.format(str(y)))
 ```
 
-Copy the above code into a file, and download the corresponding [training]
-(http://download.tensorflow.org/data/iris_training.csv) and [test]
-(http://download.tensorflow.org/data/iris_test.csv) data sets to the same
+Copy the above code into a file, and download the corresponding
+[training](http://download.tensorflow.org/data/iris_training.csv) and
+[test](http://download.tensorflow.org/data/iris_test.csv) data sets to the same
 directory.
 
 In the following sections, you'll progressively make updates to the above code
@@ -90,11 +90,12 @@ appropriate.
 One way to address this problem would be to split model training into multiple
 `fit` calls with smaller numbers of steps in order to evaluate accuracy more
 progressively. However, this is not recommended practice, as it greatly slows down model
-training. Fortunately, tf.contrib.learn offers another solution: a [Monitor API]
-(../../api_docs/python/contrib.learn.monitors.md) designed to help you log metrics
-and evaluate your model while training is in progress. In the following sections,
-you'll learn how to enable logging in TensorFlow, set up a ValidationMonitor to do
-streaming evaluations, and visualize your metrics using TensorBoard.
+training. Fortunately, tf.contrib.learn offers another solution: a
+[Monitor API](../../api_docs/python/contrib.learn.monitors.md)designed to help
+you log metrics and evaluate your model while training is in progress. In the
+following sections, you'll learn how to enable logging in TensorFlow, set up a
+ValidationMonitor to do streaming evaluations, and visualize your metrics using
+TensorBoard.
 
 ## Enabling Logging with TensorFlow
 
@@ -178,8 +179,7 @@ Place this code right before the line instantiating the `classifier`.
 
 `ValidationMonitor`s rely on saved checkpoints to perform evaluation operations,
 so you'll want to modify instantiation of the `classifier` to add a
-[`RunConfig`]
-(../../api_docs/python/contrib.learn.md#RunConfig)
+[`RunConfig`](../../api_docs/python/contrib.learn.md#RunConfig)
 that includes `save_checkpoints_secs`, which specifies how many seconds should
 elapse between checkpoint saves during training. Because the Iris data set is
 quite small, and thus trains quickly, it makes sense to set
@@ -270,8 +270,8 @@ INFO:tensorflow:Validation (step 1600): recall = 1.0, accuracy = 0.966667, globa
 
 Note that in the above log output, by step 150, the model has already achieved
 precision and recall rates of 1.0. This raises the question as to whether model
-training could benefit from [early stopping]
-(https://en.wikipedia.org/wiki/Early_stopping).
+training could benefit from
+[early stopping](https://en.wikipedia.org/wiki/Early_stopping).
 
 In addition to logging eval metrics, `ValidationMonitor`s make it easy to
 implement early stopping when specified conditions are met, via three params:
@@ -347,9 +347,8 @@ Then load the provided URL (here, `http://0.0.0.0:6006`) in your browser. If you
 click on the accuracy field, you'll see an image like the following, which shows
 accuracy plotted against step count:
 
-![Accuracy over step count in TensorBoard]
-(../../images/validation_monitor_tensorboard_accuracy.png "Accuracy over step count in TensorBoard")
+![Accuracy over step count in TensorBoard](../../images/validation_monitor_tensorboard_accuracy.png "Accuracy over step count in TensorBoard")
 
-For more on using TensorBoard, see [TensorBoard: Visualizing Learning]
-(../../how_tos/summaries_and_tensorboard/index.md)
+For more on using TensorBoard, see
+[TensorBoard: Visualizing Learning](../../how_tos/summaries_and_tensorboard/index.md)
 and [TensorBoard: Graph Visualization](../../how_tos/graph_viz/index.md).

--- a/tensorflow/g3doc/tutorials/recurrent/index.md
+++ b/tensorflow/g3doc/tutorials/recurrent/index.md
@@ -2,8 +2,7 @@
 
 ## Introduction
 
-Take a look at [this great article]
-(http://colah.github.io/posts/2015-08-Understanding-LSTMs/)
+Take a look at [this great article](http://colah.github.io/posts/2015-08-Understanding-LSTMs/)
 for an introduction to recurrent neural networks and LSTMs in particular.
 
 ## Language Modeling

--- a/tensorflow/g3doc/tutorials/tflearn/index.md
+++ b/tensorflow/g3doc/tutorials/tflearn/index.md
@@ -2,10 +2,10 @@
 
 TensorFlow’s high-level machine learning API (tf.contrib.learn) makes it easy to
 configure, train, and evaluate a variety of machine learning models. In this
-tutorial, you’ll use tf.contrib.learn to construct a [neural network]
-(https://en.wikipedia.org/wiki/Artificial_neural_network) classifier and train
-it on the [Iris data set](https://en.wikipedia.org/wiki/Iris_flower_data_set) to
-predict flower species based on sepal/petal geometry. You'll write code to
+tutorial, you’ll use tf.contrib.learn to construct a
+[neural network](https://en.wikipedia.org/wiki/Artificial_neural_network)
+classifier and train it on the [Iris data set](https://en.wikipedia.org/wiki/Iris_flower_data_set)
+to predict flower species based on sepal/petal geometry. You'll write code to
 perform the following five steps:
 
 1.  Load CSVs containing Iris training/test data into a TensorFlow `Dataset`
@@ -15,9 +15,9 @@ perform the following five steps:
 4.  Evaluate the accuracy of the model
 5.  Classify new samples
 
-NOTE: Remember to [install TensorFlow on your machine]
-(../../get_started/os_setup.md#download-and-setup) before getting started with
-this tutorial.
+NOTE: Remember to
+[install TensorFlow on your machine](../../get_started/os_setup.md#download-and-setup)
+before getting started with this tutorial.
 
 ## Complete Neural Network Source Code
 
@@ -85,11 +85,11 @@ and [*Iris virginica*](https://www.flickr.com/photos/33397993@N05/3352169862)
 (by [Frank Mayfield](https://www.flickr.com/photos/33397993@N05), CC BY-SA
 2.0).**
 
-Each row contains the following data for each flower sample: [sepal]
-(https://en.wikipedia.org/wiki/Sepal) length, sepal width, [petal]
-(https://en.wikipedia.org/wiki/Petal) length, petal width, and flower species.
-Flower species are represented as integers, with 0 denoting *Iris setosa*, 1
-denoting *Iris versicolor*, and 2 denoting *Iris virginica*.
+Each row contains the following data for each flower sample:
+[sepal](https://en.wikipedia.org/wiki/Sepal) length, sepal width,
+[petal](https://en.wikipedia.org/wiki/Petal) length, petal width, and flower
+species. Flower species are represented as integers, with 0 denoting
+*Iris setosa*, 1 denoting *Iris versicolor*, and 2 denoting *Iris virginica*.
 
 Sepal Length | Sepal Width | Petal Length | Petal Width | Species
 :----------- | :---------- | :----------- | :---------- | :-------
@@ -126,8 +126,8 @@ import tensorflow as tf
 import numpy as np
 ```
 
-Next, load the training and test sets into `Dataset`s using the [`load_csv()`]
-(https://www.tensorflow.org/code/tensorflow/contrib/learn/python/learn/datasets/base.py)
+Next, load the training and test sets into `Dataset`s using the
+[`load_csv()`](https://www.tensorflow.org/code/tensorflow/contrib/learn/python/learn/datasets/base.py)
 method in `learn.datasets.base`. The `load_csv()` method takes two required
 arguments:
 
@@ -152,28 +152,29 @@ test_set = tf.contrib.learn.datasets.base.load_csv(filename=IRIS_TEST,
                                                    target_dtype=np.int)
 ```
 
-`Dataset`s in tf.contrib.learn are [named tuples]
-(https://docs.python.org/2/library/collections.html#collections.namedtuple); you
-can access feature data and target values via the `data` and `target` fields.
-Here, `training_set.data` and `training_set.target` contain the feature data and
-target values for the training set, respectively, and `test_set.data` and
-`test_set.target` contain feature data and target values for the test set.
+`Dataset`s in tf.contrib.learn are
+[named tuples](https://docs.python.org/2/library/collections.html#collections.namedtuple);
+you can access feature data and target values via the `data` and `target`
+fields. Here, `training_set.data` and `training_set.target` contain the feature
+data and target values for the training set, respectively, and `test_set.data`
+and `test_set.target` contain feature data and target values for the test set.
 
-Later on, in ["Fit the DNNClassifier to the Iris Training Data,"]
-(#fit-dnnclassifier) you'll use `training_set.data` and `training_set.target` to
-train your model, and in ["Evaluate Model Accuracy,"](#evaluate-accuracy) you'll
-use `test_set.data` and `test_set.target`. But first, you'll construct your
-model in the next section.
+Later on, in
+["Fit the DNNClassifier to the Iris Training Data,"](#fit-dnnclassifier)
+you'll use `training_set.data` and `training_set.target` to train your model,
+and in ["Evaluate Model Accuracy,"](#evaluate-accuracy) you'll use
+`test_set.data` and `test_set.target`. But first, you'll construct your model in
+the next section.
 
 ## Construct a Deep Neural Network Classifier
 
-tf.contrib.learn offers a variety of predefined models, called [`Estimator`s]
-(../../api_docs/python/contrib.learn.md#estimators), which you can use "out of
-the box" to run training and evaluation operations on your data. Here, you'll
-configure a Deep Neural Network Classifier model to fit the Iris data. Using
-tf.contrib.learn, you can instantiate your [`DNNClassifier`]
-(../../api_docs/python/contrib.learn.md#DNNClassifier) with just a couple lines
-of code:
+tf.contrib.learn offers a variety of predefined models, called
+[`Estimator`s](../../api_docs/python/contrib.learn.md#estimators), which you can
+use "out of the box" to run training and evaluation operations on your data.
+Here, you'll configure a Deep Neural Network Classifier model to fit the Iris
+data. Using tf.contrib.learn, you can instantiate your
+[`DNNClassifier`](../../api_docs/python/contrib.learn.md#DNNClassifier)
+with just a couple lines of code:
 
 ```python
 # Specify that all features have real-value data
@@ -208,9 +209,9 @@ Then, the code creates a `DNNClassifier` model using the following arguments:
 ## Fit the DNNClassifier to the Iris Training Data {#fit-dnnclassifier}
 
 Now that you've configured your DNN `classifier` model, you can fit it to the
-Iris training data using the [`fit`]
-(../../api_docs/python/contrib.learn.md#BaseEstimator.fit) method. Pass as
-arguments your feature data (`training_set.data`), target values
+Iris training data using the
+[`fit`](../../api_docs/python/contrib.learn.md#BaseEstimator.fit) method. Pass
+as arguments your feature data (`training_set.data`), target values
 (`training_set.target`), and the number of steps to train (here, 2000):
 
 ```python
@@ -228,8 +229,8 @@ classifier.fit(x=training_set.data, y=training_set.target, steps=1000)
 ```
 
 However, if you're looking to track the model while it trains, you'll likely
-want to instead use a TensorFlow [`monitor`]
-(https://www.tensorflow.org/code/tensorflow/contrib/learn/python/learn/monitors.py)
+want to instead use a TensorFlow
+[`monitor`](https://www.tensorflow.org/code/tensorflow/contrib/learn/python/learn/monitors.py)
 to perform logging operations. See the tutorial [&ldquo;Logging and Monitoring
 Basics with tf.contrib.learn&rdquo;](../monitors/index.md) for more on this
 topic.
@@ -237,12 +238,12 @@ topic.
 ## Evaluate Model Accuracy {#evaluate-accuracy}
 
 You've fit your `DNNClassifier` model on the Iris training data; now, you can
-check its accuracy on the Iris test data using the [`evaluate`]
-(../../api_docs/python/contrib.learn.md#BaseEstimator.evaluate) method. Like
-`fit`, `evaluate` takes feature data and target values as arguments, and returns
-a `dict` with the evaluation results. The following code passes the Iris test
-data&mdash;`test_set.data` and `test_set.target`&mdash;to `evaluate` and prints
-the `accuracy` from the results:
+check its accuracy on the Iris test data using the
+[`evaluate`](../../api_docs/python/contrib.learn.md#BaseEstimator.evaluate)
+method. Like `fit`, `evaluate` takes feature data and target values as
+arguments, and returns a `dict` with the evaluation results. The following code
+passes the Iris test data&mdash;`test_set.data` and `test_set.target`&mdash;to
+`evaluate` and prints the `accuracy` from the results:
 
 ```python
 accuracy_score = classifier.evaluate(x=test_set.data, y=test_set.target)["accuracy"]

--- a/tensorflow/g3doc/tutorials/wide/index.md
+++ b/tensorflow/g3doc/tutorials/wide/index.md
@@ -36,8 +36,9 @@ https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/w
        $ sudo pip install pandas
        ```
 
-    If you have trouble installing pandas, consult the [instructions]
-(http://pandas.pydata.org/pandas-docs/stable/install.html) on the pandas site.
+    If you have trouble installing pandas, consult the
+    [instructions](http://pandas.pydata.org/pandas-docs/stable/install.html)
+    on the pandas site.
 
 4. Execute the tutorial code with the following command to train the linear
 model described in this tutorial:
@@ -50,12 +51,11 @@ Read on to find out how this code builds its linear model.
 
 ## Reading The Census Data
 
-The dataset we'll be using is the [Census Income Dataset]
-(https://archive.ics.uci.edu/ml/datasets/Census+Income). You can download the
-[training data]
-(https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data) and
-[test data]
-(https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.test)
+The dataset we'll be using is the
+[Census Income Dataset](https://archive.ics.uci.edu/ml/datasets/Census+Income).
+You can download the
+[training data](https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data)
+and [test data](https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.test)
 manually or use code like this:
 
 ```python
@@ -67,8 +67,8 @@ urllib.urlretrieve("https://archive.ics.uci.edu/ml/machine-learning-databases/ad
 urllib.urlretrieve("https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.test", test_file.name)
 ```
 
-Once the CSV files are downloaded, let's read them into [Pandas]
-(http://pandas.pydata.org/) dataframes.
+Once the CSV files are downloaded, let's read them into
+[Pandas](http://pandas.pydata.org/) dataframes.
 
 ```python
 import pandas as pd
@@ -147,10 +147,9 @@ When building a TF.Learn model, the input data is specified by means of an Input
 Builder function. This builder function will not be called until it is later
 passed to TF.Learn methods such as `fit` and `evaluate`. The purpose of this
 function is to construct the input data, which is represented in the form of
-[Tensors]
-(https://www.tensorflow.org/versions/r0.9/api_docs/python/framework.html#Tensor)
-or [SparseTensors]
-(https://www.tensorflow.org/versions/r0.9/api_docs/python/sparse_ops.html#SparseTensor).
+[Tensors](https://www.tensorflow.org/versions/r0.9/api_docs/python/framework.html#Tensor)
+or
+[SparseTensors](https://www.tensorflow.org/versions/r0.9/api_docs/python/sparse_ops.html#SparseTensor).
 In more detail, the Input Builder function returns the following as a pair:
 
 1.  `feature_cols`: A dict from feature column names to `Tensors` or
@@ -170,8 +169,7 @@ Our model represents the input data as *constant* tensors, meaning that the
 tensor represents a constant value, in this case the values of a particular
 column of `df_train` or `df_test`. This is the simplest way to pass data into
 TensorFlow. Another more advanced way to represent input data would be to
-construct an [Input Reader]
-(https://www.tensorflow.org/versions/r0.9/api_docs/python/io_ops.html#inputs-and-readers)
+construct an [Input Reader](https://www.tensorflow.org/versions/r0.9/api_docs/python/io_ops.html#inputs-and-readers)
 that represents a file or other data source, and iterates through the file as
 TensorFlow runs the graph. Each continuous column in the train or test dataframe
 will be converted into a `Tensor`, which in general is a good format to
@@ -387,9 +385,8 @@ The first line of the output should be something like `accuracy: 0.83557522`,
 which means the accuracy is 83.6%. Feel free to try more features and
 transformations and see if you can do even better!
 
-If you'd like to see a working end-to-end example, you can download our [example
-code]
-(https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/wide_n_deep_tutorial.py)
+If you'd like to see a working end-to-end example, you can download our
+[example code](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/wide_n_deep_tutorial.py)
 and set the `model_type` flag to `wide`.
 
 ## Adding Regularization to Prevent Overfitting

--- a/tensorflow/g3doc/tutorials/wide_and_deep/index.md
+++ b/tensorflow/g3doc/tutorials/wide_and_deep/index.md
@@ -16,8 +16,7 @@ large-scale regression and classification problems with sparse input features
 you're interested in learning more about how Wide & Deep Learning works, please
 check out our [research paper](http://arxiv.org/abs/1606.07792).
 
-![Wide & Deep Spectrum of Models]
-(../../images/wide_n_deep.svg "Wide & Deep")
+![Wide & Deep Spectrum of Models](../../images/wide_n_deep.svg "Wide & Deep")
 
 The figure above shows a comparison of a wide model (logistic regression with
 sparse features and transformations), a deep model (feed-forward neural network
@@ -62,8 +61,9 @@ https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/w
        $ sudo pip install pandas
        ```
 
-    If you have trouble installing pandas, consult the [instructions]
-(http://pandas.pydata.org/pandas-docs/stable/install.html) on the pandas site.
+    If you have trouble installing pandas, consult the
+    [instructions](http://pandas.pydata.org/pandas-docs/stable/install.html)
+    on the pandas site.
 
 4. Execute the tutorial code with the following command to train the linear
 model described in this tutorial:
@@ -130,9 +130,9 @@ concatenated with the continuous features, and then fed into the hidden layers
 of a neural network in the forward pass. The embedding values are initialized
 randomly, and are trained along with all other model parameters to minimize the
 training loss. If you're interested in learning more about embeddings, check out
-the TensorFlow tutorial on [Vector Representations of Words]
-(https://www.tensorflow.org/versions/r0.9/tutorials/word2vec/index.html), or
-[Word Embedding](https://en.wikipedia.org/wiki/Word_embedding) on Wikipedia.
+the TensorFlow tutorial on
+[Vector Representations of Words](https://www.tensorflow.org/versions/r0.9/tutorials/word2vec/index.html),
+or [Word Embedding](https://en.wikipedia.org/wiki/Word_embedding) on Wikipedia.
 
 We'll configure the embeddings for the categorical columns using
 `embedding_column`, and concatenate them with the continuous columns:
@@ -259,8 +259,8 @@ for key in sorted(results):
 The first line of the output should be something like `accuracy: 0.84429705`. We
 can see that the accuracy was improved from about 83.6% using a wide-only linear
 model to about 84.4% using a Wide & Deep model. If you'd like to see a working
-end-to-end example, you can download our [example code]
-(https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/wide_n_deep_tutorial.py).
+end-to-end example, you can download our
+[example code](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/wide_n_deep_tutorial.py).
 
 Note that this tutorial is just a quick example on a small dataset to get you
 familiar with the API. Wide & Deep Learning will be even more powerful if you

--- a/tensorflow/python/lib/core/py_func.cc
+++ b/tensorflow/python/lib/core/py_func.cc
@@ -15,6 +15,8 @@ limitations under the License.
 
 #include "tensorflow/python/lib/core/py_func.h"
 
+#include <array>
+
 #include <Python.h>
 #include "numpy/arrayobject.h"
 #include "tensorflow/core/framework/op_kernel.h"
@@ -162,8 +164,8 @@ bool IsSingleNone(PyObject* obj) {
   if (PyArray_NDIM(array_obj) != 0 || PyArray_SIZE(array_obj) != 1) {
     return false;
   }
-  npy_intp indices[] = {};
-  char* item_ptr = static_cast<char*>(PyArray_GetPtr(array_obj, indices));
+  std::array<npy_intp, 0> indices;
+  char* item_ptr = static_cast<char*>(PyArray_GetPtr(array_obj, indices.data()));
   PyObject* item = PyArray_GETITEM(array_obj, item_ptr);
   CHECK(item);
   return item == Py_None;

--- a/tensorflow/python/ops/nn.py
+++ b/tensorflow/python/ops/nn.py
@@ -142,9 +142,8 @@ to the `Convolution` section for details about the padding calculation.
 
 Morphological operators are non-linear filters used in image processing.
 
-[Greyscale morphological dilation]
-(https://en.wikipedia.org/wiki/Dilation_(morphology)) is the max-sum counterpart
-of standard sum-product convolution:
+[Greyscale morphological dilation](https://en.wikipedia.org/wiki/Dilation_(morphology))
+is the max-sum counterpart of standard sum-product convolution:
 
     output[b, y, x, c] =
         max_{dy, dx} input[b,
@@ -157,9 +156,8 @@ The `filter` is usually called structuring function. Max-pooling is a special
 case of greyscale morphological dilation when the filter assumes all-zero
 values (a.k.a. flat structuring function).
 
-[Greyscale morphological erosion]
-(https://en.wikipedia.org/wiki/Erosion_(morphology)) is the min-sum counterpart
-of standard sum-product convolution:
+[Greyscale morphological erosion](https://en.wikipedia.org/wiki/Erosion_(morphology))
+is the min-sum counterpart of standard sum-product convolution:
 
     output[b, y, x, c] =
         min_{dy, dx} input[b,
@@ -255,8 +253,8 @@ Candidate Sampling training algorithms can speed up your step times by
 only considering a small randomly-chosen subset of contrastive classes
 (called candidates) for each batch of training examples.
 
-See our [Candidate Sampling Algorithms Reference]
-(../../extras/candidate_sampling.pdf)
+See our
+[Candidate Sampling Algorithms Reference](../../extras/candidate_sampling.pdf)
 
 ### Sampled Loss Functions
 

--- a/tensorflow/tools/dist_test/README.md
+++ b/tensorflow/tools/dist_test/README.md
@@ -112,5 +112,5 @@ servers. For example:
 
     kubectl create -f tf-k8s-with-lb.yaml
 
-See [Kubernetes kubectl documentation]
-(http://kubernetes.io/docs/user-guide/kubectl-overview/) for more details.
+See [Kubernetes kubectl documentation](http://kubernetes.io/docs/user-guide/kubectl-overview/)
+for more details.


### PR DESCRIPTION
Refer to [markdown syntax](https://daringfireball.net/projects/markdown/syntax#link),
the `[` should come after `)` without spaces or new line character. This fixs
the broken links when generate PDF/EPUB books by Gitbook.
